### PR TITLE
adding an option for installing the dependencies required

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ $ cd waymore
 $ sudo python setup.py install
 ```
 
+if you're having a problem running the **`setup.py`** for whatever reason
+you can run the following to install the dependencies:
+
+```
+$ sudo pip3 install -r requirements.txt
+```
+
 ## Usage
 
 | Arg           | Long Arg                | Description                                                                                                                                                                                                                                                                                                      |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+argparse
+PyYAML==6.0
+requests==2.22.0
+setuptools==45.2.0
+termcolor==1.1.0


### PR DESCRIPTION
If the setuptools module not installed, the `setup.py` file will not run, so i added an option to install the dependencies by adding a requirements.txt file to install all the modules required for waymore to run and/or the `setup.py` to run.

Added this because it might solve user issues in the future.