### PR TITLE
Fix missing tqdm as requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ termcolor
 psutil
 urlparse3
 tldextract
+tqdm

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     author="@xnl-h4ck3r",
     url="https://github.com/xnl-h4ck3r/waymore",
     py_modules=["waymore"],
-    install_requires=["argparse","requests","pyyaml","termcolor","psutil","urlparse3","tldextract"],
+    install_requires=["argparse","requests","pyyaml","termcolor","psutil","urlparse3","tldextract","tqdm"],
     entry_points={
         'console_scripts': [
             'waymore = waymore.waymore:main',


### PR DESCRIPTION
```
$ waymore --versiom
Traceback (most recent call last):
  File "/home/ubuntu/.local/bin/waymore", line 5, in <module>
    from waymore.waymore import main
  File "/home/ubuntu/.local/lib/python3.10/site-packages/waymore/waymore.py", line 33, in <module>
    from tqdm import tqdm
ModuleNotFoundError: No module named 'tqdm'
```