### PR TITLE
Fixes pipx installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pip install --upgrade waymore
 Quick setup in isolated python environment using [pipx](https://pypa.github.io/pipx/)
 
 ```bash
-pipx install git+https://github.com/xnl-h4ck3r/waymore.git
+pipx install git+https://github.com/xnl-h4ck3r/waymore
 ```
 
 ## Usage


### PR DESCRIPTION
For some reason, adding the `.git` at the end breaks it on my mac (it seems to be trying to request the wrong URL).

```
fatal: unable to access 'https://github.com/xnl-h4ck3r/waymore.git/': Failed to connect to github.com port 443 after 71 ms: Couldn't connect to server
```

I am not sure if it works on Linux/Windows. I am suggesting the change to make it an easy fix if that's a global issue.